### PR TITLE
SCRS 11397

### DIFF
--- a/app/config/microserviceGlobal.scala
+++ b/app/config/microserviceGlobal.scala
@@ -90,6 +90,7 @@ object MicroserviceGlobal extends DefaultMicroserviceGlobal with RunMode with Mi
     recreateSubscription(app)
 
     app.injector.instanceOf[AppStartupJobs].logIncorpInfo()
+    app.injector.instanceOf[AppStartupJobs].logRemainingSubscriptionIdentifiers()
 
     super.onStart(app)
   }
@@ -180,6 +181,17 @@ class AppStartupJobs @Inject()(config: Configuration,
             } - """ +
             s"""queue: ${queuedUpdate.fold("No queued incorp update")(_ => "In queue")}""")
         }
+      }
+    }
+  }
+
+  def logRemainingSubscriptionIdentifiers(): Unit = {
+    val regime = config.getString("log-regime").getOrElse("ct")
+
+    subsRepo.repo.getSubscriptionsByRegime(regime) map { subs =>
+      Logger.info(s"Logging existing subscriptions for $regime regime, found ${subs.size} subscriptions")
+      subs foreach { sub =>
+        Logger.info(s"[Subscription] [$regime] Transaction ID: ${sub.transactionId}, Subscriber: ${sub.subscriber}")
       }
     }
   }

--- a/app/repositories/SubscriptionsRepository.scala
+++ b/app/repositories/SubscriptionsRepository.scala
@@ -47,6 +47,8 @@ trait SubscriptionsRepository extends Repository[Subscription, BSONObjectID] {
 
   def getSubscriptions(transactionId: String): Future[Seq[Subscription]]
 
+  def getSubscriptionsByRegime(regime: String, max: Int = 20): Future[Seq[Subscription]]
+
   def getSubscriptionStats(): Future[Map[String, Int]]
 
   def wipeTestData(): Future[WriteResult]
@@ -106,6 +108,13 @@ class SubscriptionsMongoRepository(mongo: () => DB) extends ReactiveRepository[S
   def getSubscriptions(transactionId: String): Future[Seq[Subscription]] = {
     val query = BSONDocument("transactionId" -> transactionId)
     collection.find(query).cursor[Subscription]().collect[Seq]()
+  }
+
+  def getSubscriptionsByRegime(regime: String, max: Int = 20): Future[Seq[Subscription]] = {
+    val query = BSONDocument("regime" -> regime)
+    collection
+      .find(query)
+      .cursor[Subscription]().collect[Seq](upTo = max)
   }
 
   def getSubscriptionStats(): Future[Map[String, Int]] = {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -198,7 +198,6 @@ microservice {
       transaction-id-to-poll = "dGVzdA=="
       crn-to-poll = "dGVzdA=="
 
-
       incorp-update-api {
         url = "https://ewfgonzo.companieshouse.gov.uk"
         stub-url = "http://localhost:9986/incorporation-frontend-stubs"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,9 @@ resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.co
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.6.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.8.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.10.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.0.0")
 


### PR DESCRIPTION
# SCRS-11397 - Added a start up job to provide information on remaining CT subscriptions in Live. 

**New feature**
Added a start up job to provide information on remaining CT subscriptions in Live. 

Both the Transaction ID and Subscriber are logged for documents returned. Currently, there is a limit of 20 documents in place and default regime is CT (regime can be changed by config, currently limit cannot).

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
