### PR TITLE
SCRS-11003 Added SIC code APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,32 @@ A ```200``` response:
 ```
 
 A ```404``` response: ```no body```
+
+
+
+| Path                                                                | Supported Methods | Description |
+| ------------------------------------------------------------------- | ----------------- | ----------- |
+|```/incorporation-information/sic-codes/transaction/:transactionId```|       GET         | Fetches a companies sic codes using a transaction ID, this priorities Public information but defers to the pre-incorporation API if nothing is found
+|```/incorporation-information/sic-codes/crn/:crn```                  |       GET         | Fetches an incorporated companies sic codes using its Company Number
+
+Responds with:
+
+| Status        | Message       |
+|:--------------|:--------------|
+| 200           | OK            |
+| 204           | No Content    |
+
+**Response body**
+
+A ```200``` response:
+```json
+{
+  "sic_codes": [
+    "12345",
+    "67890",
+    "55555"
+  ]
+}
+```
+
+A ```204``` response: ```no body```

--- a/app/controllers/TransactionalController.scala
+++ b/app/controllers/TransactionalController.scala
@@ -17,7 +17,6 @@
 package controllers
 
 import javax.inject.Inject
-
 import config.MicroserviceConfig
 import connectors.PublicCohoApiConnector
 import models.IncorpUpdate
@@ -29,6 +28,7 @@ import services.{TransactionalService, TransactionalServiceException}
 import uk.gov.hmrc.play.microservice.controller.BaseController
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 
 class TransactionalControllerImpl @Inject()(config: MicroserviceConfig,
@@ -84,5 +84,22 @@ trait TransactionalController extends BaseController {
         case _ => NoContent
       }
   }
+
+  def fetchSicCodesByTransactionID(txId: String) = Action.async {
+    implicit request =>
+      service.fetchSicByTransId(txId) map {
+        case Some(sicCodes) => Ok(sicCodes)
+        case _ => NoContent
+      }
+  }
+
+  def fetchSicCodesByCRN(crn: String) = Action.async {
+    implicit request =>
+      service.fetchSicByCRN(crn) map {
+        case Some(json) => Ok(json)
+        case None => NoContent
+      }
+  }
+
 }
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -9,7 +9,5 @@ POST       /subscribe/:transId/regime/:regime/subscriber/:sub          @controll
 DELETE     /subscribe/:transId/regime/:regime/subscriber/:sub          @controllers.SubscriptionController.removeSubscription(transId, regime, sub)
 GET        /subscribe/:transId/regime/:regime/subscriber/:sub          @controllers.SubscriptionController.getSubscription(transId, regime, sub)
 
-
-
-
-
+GET        /sic-codes/transaction/:txId                                @controllers.TransactionalController.fetchSicCodesByTransactionID(txId)
+GET        /sic-codes/crn/:crn                                         @controllers.TransactionalController.fetchSicCodesByCRN(crn)

--- a/project/MicroService.scala
+++ b/project/MicroService.scala
@@ -1,5 +1,20 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import sbt.Keys._
-import sbt.Tests.{SubProcess, Group}
 import sbt._
 import play.routes.compiler.StaticRoutesGenerator
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin._
@@ -9,13 +24,10 @@ trait MicroService {
 
   import uk.gov.hmrc._
   import DefaultBuildSettings._
-  import uk.gov.hmrc.{SbtBuildInfo, ShellPrompt, SbtAutoBuildPlugin}
+  import uk.gov.hmrc.SbtAutoBuildPlugin
   import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin
   import uk.gov.hmrc.versioning.SbtGitVersioning
   import play.sbt.routes.RoutesKeys.routesGenerator
-
-
-  import TestPhases._
 
   val appName: String
 
@@ -49,23 +61,5 @@ trait MicroService {
     )
     .configs(IntegrationTest)
     .settings(inConfig(IntegrationTest)(Defaults.itSettings): _*)
-    .settings(
-      fork in Test := true,
-      Keys.fork in IntegrationTest := false,
-      unmanagedSourceDirectories in IntegrationTest <<= (baseDirectory in IntegrationTest)(base => Seq(base / "it")),
-      addTestReportOption(IntegrationTest, "int-test-reports"),
-      testGrouping in IntegrationTest := oneForkedJvmPerTest((definedTests in IntegrationTest).value),
-      parallelExecution in IntegrationTest := false)
-      .settings(resolvers ++= Seq(
-        Resolver.bintrayRepo("hmrc", "releases"),
-        Resolver.jcenterRepo
-      ))
-}
-
-private object TestPhases {
-
-  def oneForkedJvmPerTest(tests: Seq[TestDefinition]) =
-    tests map {
-      test => new Group(test.name, Seq(test), SubProcess(ForkOptions(runJVMOptions = Seq("-Dtest.name=" + test.name))))
-    }
+    .settings(integrationTestSettings())
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,11 +2,11 @@ resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.co
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.11.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.10.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.1.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.12")
 


### PR DESCRIPTION
# SCRS-11003 Added SIC codes APIs, supporting both TransactionIds and CRNs

**New feature**

There are now an additional two APIs that call out to two different Companies House APIs. The first uses a CRN to talk to the Public CH API. The second uses the internal Transaction ID to query the transactional API (only supports SCRS registrations).

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
