### PR TITLE
SCRS-12857 - new API for shareholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,3 +173,35 @@ A ```200``` response:
 ```
 
 A ```204``` response: ```no body```
+
+
+| Path                                                          | Supported Methods | Description |
+| ------------------------------------------------------------- | ----------------- | ----------- |
+|```/incorporation-information/shareholders/:txId```            |       GET         | Fetches a pre-incorporated companies shareholder list keyed on the transactionId
+
+Responds with:
+
+| Status        | Message       |
+|:--------------|:--------------|
+| 200           | OK            |
+| 204           | No Content    |
+| 404           | NotFound      |
+
+A ```200``` response:
+```json
+[
+  {
+  "subscriber_type": "corporate",
+    "name": "big company",
+    "address": {
+    "premises": "11",
+    "address_line_1": " Add l 1",
+    "address_line_2": "Add l 2",
+    "locality": "London",
+    "country": "United Kingdom",
+    "postal_code": "postcode"
+    },
+  "percentage_voting_rights": 75.34
+  }
+  ]
+```

--- a/app/connectors/IncorporationAPIConnector.scala
+++ b/app/connectors/IncorporationAPIConnector.scala
@@ -137,7 +137,6 @@ trait IncorporationAPIConnector extends AlertLogging {
     } recover handleError(timepoint)
   }
 
-
   def fetchTransactionalData(transactionID: String)(implicit hc: HeaderCarrier): Future[TransactionalAPIResponse] = {
     val (http, realHc, url) = useProxy match {
       case true => (httpProxy, createAPIAuthHeader, s"$cohoBaseUrl/submissionData/$transactionID")

--- a/app/controllers/TransactionalController.scala
+++ b/app/controllers/TransactionalController.scala
@@ -53,6 +53,15 @@ trait TransactionalController extends BaseController {
       }
   }
 
+  def fetchShareholders(transactionId: String) = Action.async {
+    implicit request =>
+      service.fetchShareholders(transactionId).map {
+        case Some(json) if json.value.nonEmpty => Ok(json)
+        case Some(_) => NoContent
+        case _ => NotFound
+      }
+  }
+
   def fetchIncorporatedCompanyProfile(crn: String) = Action.async {
     implicit request =>
       val callingService = request.headers.get("User-Agent").getOrElse("unknown")

--- a/app/models/Shareholders.scala
+++ b/app/models/Shareholders.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.Logger
+import play.api.libs.json._
+
+object Shareholders {
+  val reads = new Reads[Option[JsArray]] {
+    override def reads(json: JsValue): JsResult[Option[JsArray]] = {
+      val j = json \ "shareholders"
+      JsSuccess(j.validateOpt[JsArray].fold[Option[JsArray]](_ => {
+        Logger.error("[ShareholdersReads] 'shareholders' is not an array")
+        Option.empty
+      },identity))
+    }
+  }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -11,3 +11,5 @@ GET        /subscribe/:transId/regime/:regime/subscriber/:sub          @controll
 
 GET        /sic-codes/transaction/:txId                                @controllers.TransactionalController.fetchSicCodesByTransactionID(txId)
 GET        /sic-codes/crn/:crn                                         @controllers.TransactionalController.fetchSicCodesByCRN(crn)
+
+GET        /shareholders/:txId                                         @controllers.TransactionalController.fetchShareholders(txId)

--- a/it/apis/TransactionalControllerISpec.scala
+++ b/it/apis/TransactionalControllerISpec.scala
@@ -20,6 +20,7 @@ import com.github.tomakehurst.wiremock.client.WireMock._
 import helpers.IntegrationSpecBase
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.{JsArray, Json}
 
 class TransactionalControllerISpec extends IntegrationSpecBase {
 
@@ -199,5 +200,80 @@ class TransactionalControllerISpec extends IntegrationSpecBase {
       result.status shouldBe 204
     }
   }
+  "fetchShareholders" should {
+    val txid = "transid"
 
+    "return 200 with a list of shareholders" in {
+      stubFor(get(urlMatching(s"/submissionData/$txid"))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withBody(
+              """{
+                |"foo":"bar",
+                |"shareholders": [
+                |  {
+                |  "subscriber_type": "corporate",
+                |    "name": "big company",
+                |    "address": {
+                |    "premises": "11",
+                |    "address_line_1": "Drury Lane",
+                |    "address_line_2": "West End",
+                |    "locality": "London",
+                |    "country": "United Kingdom",
+                |    "postal_code": "SW2 B2B"
+                |    },
+                |  "percentage_voting_rights": 75.34
+                |  },
+                |   {
+                |  "subscriber_type": "corporate",
+                |    "name": "big company 1",
+                |    "address": {
+                |    "premises": "11",
+                |    "address_line_1": "Drury Lane 1",
+                |    "address_line_2": "West End 1",
+                |    "locality": "London 1",
+                |    "country": "United Kingdom 1",
+                |    "postal_code": "SW2 B2B 1"
+                |    },
+                |  "percentage_voting_rights": 20.34
+                |  }
+                |  ]
+                | }
+              """.stripMargin)))
+
+      val result = client(s"shareholders/$txid").get().futureValue
+      result.status shouldBe 200
+      result.json.as[JsArray] shouldBe Json.parse("""
+          |[
+          |  {
+          |  "subscriber_type": "corporate",
+          |    "name": "big company",
+          |    "address": {
+          |    "premises": "11",
+          |    "address_line_1": "Drury Lane",
+          |    "address_line_2": "West End",
+          |    "locality": "London",
+          |    "country": "United Kingdom",
+          |    "postal_code": "SW2 B2B"
+          |    },
+          |  "percentage_voting_rights": 75.34
+          |  },
+          |   {
+          |  "subscriber_type": "corporate",
+          |    "name": "big company 1",
+          |    "address": {
+          |    "premises": "11",
+          |    "address_line_1": "Drury Lane 1",
+          |    "address_line_2": "West End 1",
+          |    "locality": "London 1",
+          |    "country": "United Kingdom 1",
+          |    "postal_code": "SW2 B2B 1"
+          |    },
+          |  "percentage_voting_rights": 20.34
+          |  }
+          |  ]
+        """.stripMargin).as[JsArray]
+    }
+  }
 }

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -12,19 +12,19 @@ object MicroServiceBuild extends Build with MicroService {
     ws,
     "com.enragedginger" %% "akka-quartz-scheduler" % "1.8.0-akka-2.5.x",
     "uk.gov.hmrc" %% "bootstrap-play-25" % "4.9.0",
-    "uk.gov.hmrc" %% "domain" % "5.3.0",
-    "uk.gov.hmrc" %% "mongo-lock" % "6.10.0-play-25",
-    "uk.gov.hmrc" %% "simple-reactivemongo" % "7.12.0-play-25" force()
+    "uk.gov.hmrc" %% "domain" % "5.6.0-play-25",
+    "uk.gov.hmrc" %% "mongo-lock" % "6.12.0-play-25",
+    "uk.gov.hmrc" %% "simple-reactivemongo" % "7.16.0-play-25"
   )
 
   def test(scope: String = "test,it") = Seq(
-    "uk.gov.hmrc" %% "hmrctest" % "3.5.0-play-25" % scope,
+    "uk.gov.hmrc" %% "hmrctest" % "3.6.0-play-25" % scope,
     "org.scalatest" %% "scalatest" % "3.0.0" % scope,
     "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.0" % scope,
     "org.pegdown" % "pegdown" % "1.6.0" % scope,
     "com.github.tomakehurst" % "wiremock" % "2.21.0" % "it",
     "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
     "org.mockito" % "mockito-all" % "2.0.2-beta" % scope,
-    "uk.gov.hmrc" %% "reactivemongo-test" % "4.7.0-play-25" % scope
+    "uk.gov.hmrc" %% "reactivemongo-test" % "4.10.0-play-25" % scope
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,9 @@ resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.co
 
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.14.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.16.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.17.0")
 

--- a/test/controllers/TransactionalControllerSpec.scala
+++ b/test/controllers/TransactionalControllerSpec.scala
@@ -272,4 +272,33 @@ class TransactionalControllerSpec extends SCRSSpec {
       status(result) shouldBe 204
     }
   }
+  "fetchShareholders" should {
+    "return 204 if array is empty" in new Setup {
+      when(mockService.fetchShareholders(eqTo(transactionId))(any[HeaderCarrier]))
+        .thenReturn(Future.successful(Some(Json.arr())))
+      val res = await(controller.fetchShareholders(transactionId)(FakeRequest()))
+      status(res) shouldBe 204
+    }
+
+    "return 200 if array is returned and size > 0" in new Setup {
+      when(mockService.fetchShareholders(eqTo(transactionId))(any[HeaderCarrier]))
+        .thenReturn(Future.successful(Some(Json.arr(Json.obj("foo" -> "bar")))))
+      val res = await(controller.fetchShareholders(transactionId)(FakeRequest()))
+      status(res) shouldBe 200
+      jsonBodyOf(res) shouldBe Json.parse(
+        """[
+          | {
+          |   "foo": "bar"
+          | }
+          |]
+        """.stripMargin)
+
+    }
+    "return 404 if key does not exist in the json and service returned None" in new Setup {
+      when(mockService.fetchShareholders(eqTo(transactionId))(any[HeaderCarrier]))
+        .thenReturn(Future.successful(None))
+      val res = await(controller.fetchShareholders(transactionId)(FakeRequest()))
+      status(res) shouldBe 404
+    }
+  }
 }

--- a/test/models/ShareholdersSpec.scala
+++ b/test/models/ShareholdersSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.Logger
+import play.api.libs.json.{JsArray, Json}
+import uk.gov.hmrc.play.test.{LogCapturing, UnitSpec}
+
+class ShareholdersSpec extends UnitSpec with LogCapturing{
+
+  "return None if no key exists" in {
+    val json =
+      Json.parse(
+        """
+          |{
+          |   "foo" : "bar"
+          |}
+        """.stripMargin)
+    json.as[Option[JsArray]](Shareholders.reads).isDefined shouldBe false
+  }
+  "return None if key exists but is not a JsArray" in {
+    val json =
+      Json.parse(
+        """
+          |{
+          |   "shareholders" : "bar"
+          |}
+        """.stripMargin)
+    withCaptureOfLoggingFrom(Logger) { logEvents =>
+      json.as[Option[JsArray]](Shareholders.reads).isDefined shouldBe false
+      val message = "[ShareholdersReads] 'shareholders' is not an array"
+      val log =  logEvents.map(l => (l.getLevel, l.getMessage)).head
+      log._1.toString shouldBe "ERROR"
+      log._2 shouldBe message
+    }
+  }
+  "return Some if key exists and is jsArray" in {
+    val json =
+      Json.parse(
+        """
+          |{
+          |   "shareholders" : []
+          |}
+        """.stripMargin)
+    json.as[Option[JsArray]](Shareholders.reads).get shouldBe Json.arr()
+  }
+}


### PR DESCRIPTION
added in route to return list of shareholders and uplifted deps 200 for valid list of shareholders, 204 for empty list of shareholders 404 for no key identified in the json if shareholders is not a JsArray this is logged as an error and we return None back to the controller, which is interpretted as a 404

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date 
