### PR TITLE
[parameterisedStartUpJobDelay] Add ability to delay the startUpJobs by a configurable parameter

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -92,6 +92,11 @@ akka.quartz {
   }
   defaultTimezone = UTC
 }
+
+startUpJob {
+  initialDelayMillis = 0
+}
+
 schedules.fire-subs-job {
   enabled          = false
   description     = "fire subscriptions job"

--- a/test/config/AppStartupJobsSpec.scala
+++ b/test/config/AppStartupJobsSpec.scala
@@ -22,6 +22,7 @@ import models.{IncorpUpdate, QueuedIncorpUpdate, Subscription}
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Millis, Span}
 import play.api.test.DefaultAwaitTimeout
 import play.api.{Configuration, Logger}
 import repositories._
@@ -46,6 +47,7 @@ class AppStartupJobsSpec extends SCRSSpec with LogCapturing with Eventually with
 
   val mockQueueMongo: QueueMongo = mock[QueueMongo]
   val mockQueueRepo: QueueMongoRepository = mock[QueueMongoRepository]
+  val mockConfig: MicroserviceConfig = mock[MicroserviceConfig]
 
   implicit val hc = HeaderCarrier()
 
@@ -53,12 +55,14 @@ class AppStartupJobsSpec extends SCRSSpec with LogCapturing with Eventually with
     reset(
       mockSubsMongo, mockSubsRepo,
       mockIncorpUpdateMongo, mockIncorpUpdateRepo,
-      mockQueueMongo, mockQueueRepo, mockIIService, mocksubService
+      mockQueueMongo, mockQueueRepo, mockIIService, mocksubService, mockConfig
     )
   }
 
-  class Setup {
+  class Setup(delay: Int = 0) {
     resetMocks()
+
+    when(mockConfig.getConfigInt("startUpJob.initialDelayMillis")).thenReturn(delay)
 
     def appStartupJobs(config: Configuration): StartUpJobs = new StartUpJobs(
       config,
@@ -67,14 +71,16 @@ class AppStartupJobsSpec extends SCRSSpec with LogCapturing with Eventually with
       mocktpRepo,
       mockSubsMongo,
       mockIncorpUpdateMongo,
-      mockQueueMongo
+      mockQueueMongo,
+      mockConfig
     )
 
   }
 
-  "logRemainingSubscriptionIdentifiers" must {
+  "when there is a delay set" must {
 
-    "log information about subscriptions with default values as nothing exists in config" in new Setup {
+    "wait for the delay before executing" in new Setup(5000) {
+
       val subscription1 = Subscription("transId", "testRegime", "testSubscriber", "testCallbackUrl")
       val subscriptions: Seq[Subscription] = Seq.fill(5)(subscription1)
       when(mockSubsMongo.repo).thenReturn(mockSubsRepo)
@@ -90,155 +96,193 @@ class AppStartupJobsSpec extends SCRSSpec with LogCapturing with Eventually with
       }
 
       withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
+
+        val t0 = System.currentTimeMillis()
+
         appStartupJobs(Configuration())
-        eventually {
+
+        val t1 = eventually {
           logEvents.map(_.getMessage).count(r => expectedLogOfSubscriptions.contains(r)) mustBe 6
-        }
-      }
-    }
+          System.currentTimeMillis()
+        }(PatienceConfig(scaled(Span(10000, Millis)), scaled(Span(500, Millis))), implicitly, implicitly)
 
-    "log the job ran but retrieved nothing when there are no subscriptions" in new Setup {
-      when(mockSubsMongo.repo).thenReturn(mockSubsRepo)
-      when(mockIncorpUpdateMongo.repo).thenReturn(mockIncorpUpdateRepo)
-      when(mockQueueMongo.repo).thenReturn(mockQueueRepo)
-      when(mockIIService.updateSpecificIncorpUpdateByTP(any(), any())(any(), any())).thenReturn(Future.successful(Seq()))
-      when(mockSubsRepo.getSubscriptions(any()))
-        .thenReturn(Future.successful(Seq()))
+        val elapsed = t1 - t0
 
-      when(mockSubsRepo.getSubscriptionsByRegime(any(), any())) thenReturn Future.successful(Seq())
-
-      withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
-        appStartupJobs(Configuration())
-        eventually {
-
-          val expectedLogs = List(
-            "[StartUpJobs] Logging existing subscriptions for ct regime, found 0 subscriptions"
-          )
-          logEvents.map(_.getMessage).count(r => expectedLogs.contains(r)) mustBe 1
-        }
+        elapsed > 5000 mustBe true
       }
     }
   }
 
-  "logIncorpInfo" must {
+  "when there is no delay set" must {
 
-    val dateTime = LocalDateTime.of(2010, 6, 30, 1, 20, 0)
+    "logRemainingSubscriptionIdentifiers" when {
 
-    val transId1 = "trans-1"
-    val transId2 = "trans-2"
+      "log information about subscriptions with default values as nothing exists in config" in new Setup {
+        val subscription1 = Subscription("transId", "testRegime", "testSubscriber", "testCallbackUrl")
+        val subscriptions: Seq[Subscription] = Seq.fill(5)(subscription1)
+        when(mockSubsMongo.repo).thenReturn(mockSubsRepo)
+        when(mockIncorpUpdateMongo.repo).thenReturn(mockIncorpUpdateRepo)
+        when(mockQueueMongo.repo).thenReturn(mockQueueRepo)
+        when(mockIIService.updateSpecificIncorpUpdateByTP(any(), any())(any(), any())).thenReturn(Future.successful(Seq()))
+        when(mockSubsRepo.getSubscriptions(any())).thenReturn(Future.successful(Seq()))
+        when(mockSubsRepo.getSubscriptionsByRegime(eqTo("ct"), eqTo(20))).thenReturn(Future.successful(subscriptions))
 
-    val subscription1 = Subscription(transId1, "testRegime", "testSubscriber", "testCallbackUrl")
+        val expectedLogOfSubscriptions = {
+          List("[StartUpJobs] Logging existing subscriptions for ct regime, found 5 subscriptions") ++
+            List.fill(5)("[StartUpJobs] [Subscription] [ct] Transaction ID: transId, Subscriber: testSubscriber")
+        }
 
-    val incorpUpdate1 = IncorpUpdate(transId1, "accepted", Some("crn-1"), Some(dateTime), "12345", None)
+        withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
+          appStartupJobs(Configuration())
+          eventually {
+            logEvents.map(_.getMessage).count(r => expectedLogOfSubscriptions.contains(r)) mustBe 6
+          }
+        }
+      }
 
-    val queuedUpdate = QueuedIncorpUpdate(dateTime, incorpUpdate1)
+      "log the job ran but retrieved nothing when there are no subscriptions" in new Setup {
+        when(mockSubsMongo.repo).thenReturn(mockSubsRepo)
+        when(mockIncorpUpdateMongo.repo).thenReturn(mockIncorpUpdateRepo)
+        when(mockQueueMongo.repo).thenReturn(mockQueueRepo)
+        when(mockIIService.updateSpecificIncorpUpdateByTP(any(), any())(any(), any())).thenReturn(Future.successful(Seq()))
+        when(mockSubsRepo.getSubscriptions(any()))
+          .thenReturn(Future.successful(Seq()))
 
-    "log specific incorporation information relating to each transaction ID found in config" in new Setup {
-      when(mockSubsMongo.repo).thenReturn(mockSubsRepo)
-      when(mockIncorpUpdateMongo.repo).thenReturn(mockIncorpUpdateRepo)
-      when(mockQueueMongo.repo).thenReturn(mockQueueRepo)
-      when(mockIIService.updateSpecificIncorpUpdateByTP(any(), any())(any(), any())).thenReturn(Future.successful(Seq()))
-      when(mockSubsRepo.getSubscriptions(eqTo(transId1))).thenReturn(Future.successful(Seq(subscription1)))
-      when(mockSubsRepo.getSubscriptions(eqTo(transId2))).thenReturn(Future.successful(Seq()))
-      when(mockSubsRepo.getSubscriptionsByRegime(any(), any())).thenReturn(Future.successful(Seq()))
+        when(mockSubsRepo.getSubscriptionsByRegime(any(), any())) thenReturn Future.successful(Seq())
 
-      when(mockIncorpUpdateRepo.getIncorpUpdate(eqTo(transId1)))
-        .thenReturn(Future.successful(Some(incorpUpdate1)))
-      when(mockIncorpUpdateRepo.getIncorpUpdate(eqTo(transId2)))
-        .thenReturn(Future.successful(None))
+        withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
+          appStartupJobs(Configuration())
+          eventually {
 
-      when(mockQueueRepo.getIncorpUpdate(eqTo(transId1)))
-        .thenReturn(Future.successful(Some(queuedUpdate)))
-      when(mockQueueRepo.getIncorpUpdate(eqTo(transId2)))
-        .thenReturn(Future.successful(None))
-
-      val expectedLogs = List(
-        "[StartUpJobs] [HeldDocs] For txId: trans-1 - subscriptions: List(Subscription(trans-1,testRegime,testSubscriber,testCallbackUrl)) - " +
-          "incorp update: incorp status: accepted - incorp date: Some(2010-06-30T01:20:00.0) - crn: Some(crn-1) - timepoint: 12345 - queue: In queue",
-        "[StartUpJobs] [HeldDocs] For txId: trans-2 - subscriptions: No subs - incorp update: No incorp update - queue: No queued incorp update"
-      )
-
-      withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
-
-        appStartupJobs(Configuration.from(Map("transactionIdList" -> "dHJhbnMtMSx0cmFucy0y")))
-        eventually {
-          logEvents.map(_.getMessage).count(expectedLogs.contains(_)) mustBe 2
+            val expectedLogs = List(
+              "[StartUpJobs] Logging existing subscriptions for ct regime, found 0 subscriptions"
+            )
+            logEvents.map(_.getMessage).count(r => expectedLogs.contains(r)) mustBe 1
+          }
         }
       }
     }
 
-    "not log anything is an encoded transaction ID list is not provided in config" in new Setup {
-      when(mockSubsMongo.repo).thenReturn(mockSubsRepo)
-      when(mockIncorpUpdateMongo.repo).thenReturn(mockIncorpUpdateRepo)
-      when(mockQueueMongo.repo).thenReturn(mockQueueRepo)
-      when(mockIIService.updateSpecificIncorpUpdateByTP(any(), any())(any(), any())).thenReturn(Future.successful(Seq()))
-      when(mockSubsRepo.getSubscriptionsByRegime(any(), any())).thenReturn(Future.successful(Seq()))
-      withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
-        appStartupJobs(Configuration())
-        eventually {
-          logEvents.map(_.getMessage).filter(_.contains("[HeldDocs]")) mustBe empty
+    "logIncorpInfo" must {
+
+      val dateTime = LocalDateTime.of(2010, 6, 30, 1, 20, 0)
+
+      val transId1 = "trans-1"
+      val transId2 = "trans-2"
+
+      val subscription1 = Subscription(transId1, "testRegime", "testSubscriber", "testCallbackUrl")
+
+      val incorpUpdate1 = IncorpUpdate(transId1, "accepted", Some("crn-1"), Some(dateTime), "12345", None)
+
+      val queuedUpdate = QueuedIncorpUpdate(dateTime, incorpUpdate1)
+
+      "log specific incorporation information relating to each transaction ID found in config" in new Setup {
+        when(mockSubsMongo.repo).thenReturn(mockSubsRepo)
+        when(mockIncorpUpdateMongo.repo).thenReturn(mockIncorpUpdateRepo)
+        when(mockQueueMongo.repo).thenReturn(mockQueueRepo)
+        when(mockIIService.updateSpecificIncorpUpdateByTP(any(), any())(any(), any())).thenReturn(Future.successful(Seq()))
+        when(mockSubsRepo.getSubscriptions(eqTo(transId1))).thenReturn(Future.successful(Seq(subscription1)))
+        when(mockSubsRepo.getSubscriptions(eqTo(transId2))).thenReturn(Future.successful(Seq()))
+        when(mockSubsRepo.getSubscriptionsByRegime(any(), any())).thenReturn(Future.successful(Seq()))
+
+        when(mockIncorpUpdateRepo.getIncorpUpdate(eqTo(transId1)))
+          .thenReturn(Future.successful(Some(incorpUpdate1)))
+        when(mockIncorpUpdateRepo.getIncorpUpdate(eqTo(transId2)))
+          .thenReturn(Future.successful(None))
+
+        when(mockQueueRepo.getIncorpUpdate(eqTo(transId1)))
+          .thenReturn(Future.successful(Some(queuedUpdate)))
+        when(mockQueueRepo.getIncorpUpdate(eqTo(transId2)))
+          .thenReturn(Future.successful(None))
+
+        val expectedLogs = List(
+          "[StartUpJobs] [HeldDocs] For txId: trans-1 - subscriptions: List(Subscription(trans-1,testRegime,testSubscriber,testCallbackUrl)) - " +
+            "incorp update: incorp status: accepted - incorp date: Some(2010-06-30T01:20:00.0) - crn: Some(crn-1) - timepoint: 12345 - queue: In queue",
+          "[StartUpJobs] [HeldDocs] For txId: trans-2 - subscriptions: No subs - incorp update: No incorp update - queue: No queued incorp update"
+        )
+
+        withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
+
+          appStartupJobs(Configuration.from(Map("transactionIdList" -> "dHJhbnMtMSx0cmFucy0y")))
+          eventually {
+            logEvents.map(_.getMessage).count(expectedLogs.contains(_)) mustBe 2
+          }
+        }
+      }
+
+      "not log anything is an encoded transaction ID list is not provided in config" in new Setup {
+        when(mockSubsMongo.repo).thenReturn(mockSubsRepo)
+        when(mockIncorpUpdateMongo.repo).thenReturn(mockIncorpUpdateRepo)
+        when(mockQueueMongo.repo).thenReturn(mockQueueRepo)
+        when(mockIIService.updateSpecificIncorpUpdateByTP(any(), any())(any(), any())).thenReturn(Future.successful(Seq()))
+        when(mockSubsRepo.getSubscriptionsByRegime(any(), any())).thenReturn(Future.successful(Seq()))
+        withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
+          appStartupJobs(Configuration())
+          eventually {
+            logEvents.map(_.getMessage).filter(_.contains("[HeldDocs]")) mustBe empty
+          }
         }
       }
     }
-  }
 
-  "removeBrokenSubmissions" must {
+    "removeBrokenSubmissions" must {
 
-    val encodedTransIds = "dHJhbnMtMSx0cmFucy0y"
+      val encodedTransIds = "dHJhbnMtMSx0cmFucy0y"
 
-    val transId1 = "trans-1"
-    val transId2 = "trans-2"
+      val transId1 = "trans-1"
+      val transId2 = "trans-2"
 
-    val deleteResult = DeleteResult.acknowledged(1)
+      val deleteResult = DeleteResult.acknowledged(1)
 
-    "log when broken submissions are removed" in new Setup {
-      when(mockSubsMongo.repo).thenReturn(mockSubsRepo)
-      when(mockIncorpUpdateMongo.repo).thenReturn(mockIncorpUpdateRepo)
-      when(mockQueueMongo.repo).thenReturn(mockQueueRepo)
+      "log when broken submissions are removed" in new Setup {
+        when(mockSubsMongo.repo).thenReturn(mockSubsRepo)
+        when(mockIncorpUpdateMongo.repo).thenReturn(mockIncorpUpdateRepo)
+        when(mockQueueMongo.repo).thenReturn(mockQueueRepo)
 
-      when(mockSubsRepo.getSubscriptionsByRegime(any(), any())) thenReturn Future.successful(Seq())
-
-
-      when(mockSubsRepo.deleteSub(eqTo(transId1),eqTo("ctax"),eqTo("scrs")))
-        .thenReturn(Future.successful(deleteResult))
-      when(mockSubsRepo.deleteSub(eqTo(transId2),eqTo("ctax"),eqTo("scrs")))
-        .thenReturn(Future.successful(deleteResult))
+        when(mockSubsRepo.getSubscriptionsByRegime(any(), any())) thenReturn Future.successful(Seq())
 
 
-      when(mockQueueRepo.removeQueuedIncorpUpdate(eqTo(transId1)))
-        .thenReturn(Future.successful(true))
-      when(mockQueueRepo.removeQueuedIncorpUpdate(eqTo(transId2)))
-        .thenReturn(Future.successful(true))
+        when(mockSubsRepo.deleteSub(eqTo(transId1), eqTo("ctax"), eqTo("scrs")))
+          .thenReturn(Future.successful(deleteResult))
+        when(mockSubsRepo.deleteSub(eqTo(transId2), eqTo("ctax"), eqTo("scrs")))
+          .thenReturn(Future.successful(deleteResult))
 
 
-      withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
-        appStartupJobs(Configuration.from(Map("brokenTxIds" -> encodedTransIds)))
+        when(mockQueueRepo.removeQueuedIncorpUpdate(eqTo(transId1)))
+          .thenReturn(Future.successful(true))
+        when(mockQueueRepo.removeQueuedIncorpUpdate(eqTo(transId2)))
+          .thenReturn(Future.successful(true))
 
-        eventually {
-          val expectedLogs = List(
+
+        withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
+          appStartupJobs(Configuration.from(Map("brokenTxIds" -> encodedTransIds)))
+
+          eventually {
+            val expectedLogs = List(
               "[StartUpJobs] [Start Up] Removed broken submission with txId: trans-1 - delete sub: AcknowledgedDeleteResult{deletedCount=1} queue result: true",
               "[StartUpJobs] [Start Up] Removed broken submission with txId: trans-2 - delete sub: AcknowledgedDeleteResult{deletedCount=1} queue result: true"
-          )
-          logEvents.map(_.getMessage).count(expectedLogs.contains(_)) mustBe 2
+            )
+            logEvents.map(_.getMessage).count(expectedLogs.contains(_)) mustBe 2
+          }
         }
       }
-    }
 
-    "log when no broken submissions are supplied" in new Setup {
-      when(mockSubsMongo.repo).thenReturn(mockSubsRepo)
-      when(mockIncorpUpdateMongo.repo).thenReturn(mockIncorpUpdateRepo)
-      when(mockQueueMongo.repo).thenReturn(mockQueueRepo)
+      "log when no broken submissions are supplied" in new Setup {
+        when(mockSubsMongo.repo).thenReturn(mockSubsRepo)
+        when(mockIncorpUpdateMongo.repo).thenReturn(mockIncorpUpdateRepo)
+        when(mockQueueMongo.repo).thenReturn(mockQueueRepo)
 
-      when(mockSubsRepo.getSubscriptionsByRegime(any(), any())) thenReturn Future.successful(Seq())
+        when(mockSubsRepo.getSubscriptionsByRegime(any(), any())) thenReturn Future.successful(Seq())
 
-      withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
-        appStartupJobs(Configuration.from(Map()))
+        withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
+          appStartupJobs(Configuration.from(Map()))
 
-        eventually {
-          val expectedLogs = List(
-            "[StartUpJobs] [Start Up] No broken submissions in config"
-          )
-          logEvents.map(_.getMessage).count(expectedLogs.contains(_)) mustBe 1
+          eventually {
+            val expectedLogs = List(
+              "[StartUpJobs] [Start Up] No broken submissions in config"
+            )
+            logEvents.map(_.getMessage).count(expectedLogs.contains(_)) mustBe 1
+          }
         }
       }
     }


### PR DESCRIPTION
This also has the advantage of then running in its own ExecutionContext provided by the AkkaSystem for the jobName: 

**App-Config-Production:**
- https://github.com/hmrc/app-config-production/pull/16005