### PR TITLE
[SAR-10604] Some refactoring to logging for consistency

### DIFF
--- a/app/config/StartUpJobs.scala
+++ b/app/config/StartUpJobs.scala
@@ -48,7 +48,7 @@ class StartUpJobs @Inject()(val configuration: Configuration,
 
   private def reFetchIncorpInfo(): Future[Unit] = {
     tpConfig match {
-      case None => Future.successful(logger.info(s"[removeBrokenSubmissions] No timepoints to re-fetch"))
+      case None => Future.successful(logger.info(s"[reFetchIncorpInfo] No timepoints to re-fetch"))
       case Some(timepointList) =>
         val tpList = new String(Base64.getDecoder.decode(timepointList), "UTF-8")
         logger.info(s"[reFetchIncorpInfo] List of timepoints are $tpList")

--- a/app/config/StartUpJobs.scala
+++ b/app/config/StartUpJobs.scala
@@ -48,27 +48,27 @@ class StartUpJobs @Inject()(val configuration: Configuration,
 
   private def reFetchIncorpInfo(): Future[Unit] = {
     tpConfig match {
-      case None => Future.successful(logger.info(s"[Config] No timepoints to re-fetch"))
+      case None => Future.successful(logger.info(s"[removeBrokenSubmissions] No timepoints to re-fetch"))
       case Some(timepointList) =>
         val tpList = new String(Base64.getDecoder.decode(timepointList), "UTF-8")
-        logger.info(s"[Config] List of timepoints are $tpList")
+        logger.info(s"[reFetchIncorpInfo] List of timepoints are $tpList")
         incorpUpdateService.updateSpecificIncorpUpdateByTP(tpList.split(","))(HeaderCarrier(), ec) map { result =>
-          logger.info(s"Updating incorp data is switched on - result = $result")
+          logger.info(s"[reFetchIncorpInfo] Updating incorp data is switched on - result = $result")
         }
     }
   }
 
   private def recreateSubscription(): Future[Unit] = {
     configuration.getOptional[String]("resubscribe") match {
-      case None => Future.successful(logger.info(s"[Config] No re-subscriptions"))
+      case None => Future.successful(logger.info(s"[recreateSubscription] No re-subscriptions"))
       case Some(resubs) =>
         val configString = new String(Base64.getDecoder.decode(resubs), "UTF-8")
         configString.split(",").toList match {
           case txId :: callbackUrl :: Nil =>
             subscriptionService.checkForSubscription(txId, "ctax", "scrs", callbackUrl, true) map {
-              result => logger.info(s"[Config] result of subscription service call for $txId = $result")
+              result => logger.info(s"[recreateSubscription] result of subscription service call for $txId = $result")
             }
-          case _ => Future.successful(logger.info(s"[Config] No info in re-subscription variable"))
+          case _ => Future.successful(logger.info(s"[recreateSubscription] No info in re-subscription variable"))
         }
     }
   }
@@ -76,12 +76,12 @@ class StartUpJobs @Inject()(val configuration: Configuration,
   private def reFetchIncorpInfoWhenNoQueue(): Future[Unit] = {
 
     configuration.getOptional[String]("timepointListNoQueue") match {
-      case None => Future.successful(logger.info(s"[Config] No timepoints to re-fetch for no queue entries"))
+      case None => Future.successful(logger.info(s"[reFetchIncorpInfoWhenNoQueue] No timepoints to re-fetch for no queue entries"))
       case Some(timepointListNQ) =>
         val tpList = new String(Base64.getDecoder.decode(timepointListNQ), "UTF-8")
-        logger.info(s"[Config] List of timepoints for no queue entries are $tpList")
+        logger.info(s"[reFetchIncorpInfoWhenNoQueue] List of timepoints for no queue entries are $tpList")
         incorpUpdateService.updateSpecificIncorpUpdateByTP(tpList.split(","), forNoQueue = true)(HeaderCarrier(), ec) map { result =>
-          logger.info(s"Updating incorp data is switched on for no queue entries - result = $result")
+          logger.info(s"[reFetchIncorpInfoWhenNoQueue] Updating incorp data is switched on for no queue entries - result = $result")
         }
     }
   }
@@ -96,7 +96,7 @@ class StartUpJobs @Inject()(val configuration: Configuration,
           incorpUpdate <- incorpUpdateRepo.repo.getIncorpUpdate(transId)
           queuedUpdate <- queueRepo.repo.getIncorpUpdate(transId)
         } yield {
-          logger.info(s"[HeldDocs] For txId: $transId - " +
+          logger.info(s"[logIncorpInfo][HeldDocs] For txId: $transId - " +
             s"subscriptions: ${if (subscriptions.isEmpty) "No subs" else subscriptions} - " +
             s"""incorp update: ${
               incorpUpdate.fold("No incorp update")(incorp =>
@@ -117,20 +117,20 @@ class StartUpJobs @Inject()(val configuration: Configuration,
     val maxAmountToLog = configuration.getOptional[Int]("log-count").getOrElse(20)
 
     subsRepo.repo.getSubscriptionsByRegime(regime, maxAmountToLog) map { subs =>
-      logger.info(s"Logging existing subscriptions for $regime regime, found ${subs.size} subscriptions")
+      logger.info(s"[logRemainingSubscriptionIdentifiers] Logging existing subscriptions for $regime regime, found ${subs.size} subscriptions")
       subs foreach { sub =>
-        logger.info(s"[Subscription] [$regime] Transaction ID: ${sub.transactionId}, Subscriber: ${sub.subscriber}")
+        logger.info(s"[logRemainingSubscriptionIdentifiers][$regime] Transaction ID: ${sub.transactionId}, Subscriber: ${sub.subscriber}")
       }
     }
   }
 
   private def resetTimepoint(): Future[Boolean] = {
     configuration.getOptional[String]("microservice.services.reset-timepoint-to").fold {
-      logger.info("[ResetTimepoint] Could not find a timepoint to reset to (config key microservice.services.reset-timepoint-to)")
+      logger.info("[resetTimepoint] Could not find a timepoint to reset to (config key microservice.services.reset-timepoint-to)")
       Future(false)
     } {
       timepoint =>
-        logger.info(s"[ResetTimepoint] Found timepoint from config - $timepoint")
+        logger.info(s"[resetTimepoint] Found timepoint from config - $timepoint")
         timepointMongo.repo.updateTimepoint(timepoint).map(_ => true)
     }
   }
@@ -138,7 +138,7 @@ class StartUpJobs @Inject()(val configuration: Configuration,
   def removeBrokenSubmissions(): Unit = {
     val transIdsFromConfig = configuration.getOptional[String]("brokenTxIds")
     transIdsFromConfig.fold(
-      logger.info(s"[Start Up] No broken submissions in config")
+      logger.info(s"[removeBrokenSubmissions] No broken submissions in config")
     ) { transIds =>
       val transIdList = utils.Base64.decode(transIds).split(",")
       transIdList.foreach { transId =>
@@ -146,7 +146,7 @@ class StartUpJobs @Inject()(val configuration: Configuration,
           writeResult <- subsRepo.repo.deleteSub(transId,"ctax","scrs")
           queueResult <- queueRepo.repo.removeQueuedIncorpUpdate(transId)
         } yield {
-          logger.info(s"[Start Up] Removed broken submission with txId: $transId - delete sub: $writeResult queue result: $queueResult")
+          logger.info(s"[removeBrokenSubmissions] Removed broken submission with txId: $transId - delete sub: $writeResult queue result: $queueResult")
         }
       }
     }

--- a/app/connectors/PublicCohoApiConnector.scala
+++ b/app/connectors/PublicCohoApiConnector.scala
@@ -151,11 +151,11 @@ trait PublicCohoApiConnector extends AlertLogging with Logging {
         pagerduty(PagerDutyKeys.COHO_PUBLIC_API_NOT_FOUND, Some(s"Could not find company data for CRN - $crn"))
         None
       } else {
-        logger.info(s"Could not find company data for CRN - $crn")
+        logger.info(s"[getCompanyProfile] Could not find company data for CRN - $crn")
         None
       }
-    case ex: Upstream4xxResponse =>
-      pagerduty(PagerDutyKeys.COHO_PUBLIC_API_4XX, Some(s"Returned status code: ${ex.upstreamResponseCode} for $crn - reason: ${ex.getMessage}"))
+    case ex: UpstreamErrorResponse if UpstreamErrorResponse.Upstream4xxResponse.unapply(ex).isDefined =>
+      pagerduty(PagerDutyKeys.COHO_PUBLIC_API_4XX, Some(s"Returned status code: ${ex.statusCode} for $crn - reason: ${ex.getMessage}"))
       None
     case _: GatewayTimeoutException =>
       pagerduty(PagerDutyKeys.COHO_PUBLIC_API_GATEWAY_TIMEOUT, Some(s"Gateway timeout for $crn"))
@@ -163,8 +163,8 @@ trait PublicCohoApiConnector extends AlertLogging with Logging {
     case _: ServiceUnavailableException =>
       pagerduty(PagerDutyKeys.COHO_PUBLIC_API_SERVICE_UNAVAILABLE)
       None
-    case ex: Upstream5xxResponse =>
-      pagerduty(PagerDutyKeys.COHO_PUBLIC_API_5XX, Some(s"Returned status code: ${ex.upstreamResponseCode} for $crn - reason: ${ex.getMessage}"))
+    case ex: UpstreamErrorResponse if UpstreamErrorResponse.Upstream5xxResponse.unapply(ex).isDefined =>
+      pagerduty(PagerDutyKeys.COHO_PUBLIC_API_5XX, Some(s"Returned status code: ${ex.statusCode} for $crn - reason: ${ex.getMessage}"))
       None
     case ex: Throwable =>
       logger.info(s"[getCompanyProfile] - Failed for $crn - reason: ${ex.getMessage}")

--- a/app/controllers/test/ManualTriggerController.scala
+++ b/app/controllers/test/ManualTriggerController.scala
@@ -41,7 +41,7 @@ trait ManualTriggerController extends BackendBaseController with Logging {
       case INCORP_UPDATE => triggerIncorpUpdateJob
       case FIRE_SUBS => triggerFireSubsJob
       case _ =>
-        val message = s"$jobName did not match any known jobs"
+        val message = s"[$jobName] did not match any known jobs"
         logger.info(message)
         Future.successful(NotFound(message))
     }

--- a/app/repositories/TimepointRepository.scala
+++ b/app/repositories/TimepointRepository.scala
@@ -75,7 +75,7 @@ class TimepointMongoRepository(mongo: MongoComponent)
     collection.find(selector).headOption() map {
       case Some(res) => Some(res.timepoint)
       case _ =>
-        logger.warn("Could not find an existing Timepoint - this is ok for first run of the system")
+        logger.warn("[retrieveTimePoint] Could not find an existing Timepoint - this is ok for first run of the system")
         None
     }
   }

--- a/app/services/SubscriptionService.scala
+++ b/app/services/SubscriptionService.scala
@@ -64,7 +64,7 @@ trait SubscriptionService extends Logging {
     val queuedItem = incorpUpdateService.createQueuedIncorpUpdate(incorpUpdate, Some(forcedSubDelay))
     addSubscription(transactionId, regime, subscriber, callBackUrl) flatMap {
       case SuccessfulSub(_) =>
-        logger.info(s"[SubscriptionService] [forceSubscription] subscription for transaction id : $transactionId forced successfully for regime : $regime")
+        logger.info(s"[forceSubscription] subscription for transaction id : $transactionId forced successfully for regime : $regime")
         incorpUpdateService.upsertToQueue(queuedItem) map {
           case true => SuccessfulSub(forced = true)
           case _ => FailedSub
@@ -81,10 +81,10 @@ trait SubscriptionService extends Logging {
     val sub = Subscription(transactionId, regime, subscriber, callbackUrl)
     subRepo.insertSub(sub) map {
       case UpsertResult(a, b, Seq()) =>
-        logger.info(s"[MongoSubscriptionsRepository] [insertSub] $a was updated and $b was upserted for transactionId: $transactionId")
+        logger.info(s"[addSubscription] $a was updated and $b was upserted for transactionId: $transactionId")
         SuccessfulSub()
       case UpsertResult(_, _, errs) if errs.nonEmpty =>
-        logger.error(s"[SubscriptionService] [addSubscription] Error encountered when attempting to add a subscription - ${errs.toString()}")
+        logger.error(s"[addSubscription] Error encountered when attempting to add a subscription - ${errs.toString()}")
         FailedSub
     }
   }
@@ -98,11 +98,11 @@ trait SubscriptionService extends Logging {
                          subscriber: String
                         ): Future[UnsubscribeStatus] =
     subRepo.deleteSub(transactionId, regime, subscriber) map {
-      case deleted if deleted.getDeletedCount > 0 => logger.info(s"[SubscriptionService] [deleteSubscription] Subscription with transactionId: $transactionId, " +
+      case deleted if deleted.getDeletedCount > 0 => logger.info(s"[deleteSubscription] Subscription with transactionId: $transactionId, " +
         s"and regime: $regime, and subscriber: $subscriber was deleted")
         DeletedSub
       case e@_ =>
-        logger.warn(s"[SubscriptionsRepository] [deleteSub] Didn't delete the subscription with TransId: $transactionId, and regime: $regime, and subscriber: $subscriber." +
+        logger.warn(s"[deleteSubscription] Didn't delete the subscription with TransId: $transactionId, and regime: $regime, and subscriber: $subscriber." +
           s"Error message: $e")
         NotDeletedSub
     }

--- a/app/utils/Logging.scala
+++ b/app/utils/Logging.scala
@@ -21,16 +21,24 @@ import play.api.{LoggerLike, MarkerContext}
 
 trait Logging {
 
-  lazy val className: String = this.getClass.getSimpleName.stripSuffix("$")
+  private lazy val packageName: String =  this.getClass.getPackage.getName
+  private lazy val className: String = this.getClass.getSimpleName.stripSuffix("$")
 
   val logger: LoggerLike = new LoggerLike {
 
-    private lazy val prefixLog: String => String = s"[$className] " + _
-    override val logger: Logger = LoggerFactory.getLogger(s"application.$className")
+    private lazy val prefixLog: String => String = msg =>
+      s"[$className]${if (msg.startsWith("[")) msg else " " + msg}"
+
+    override val logger: Logger = LoggerFactory.getLogger(s"application.$packageName.$className")
 
     override def debug(message: => String)(implicit mc: MarkerContext): Unit = super.debug(prefixLog(message))
     override def info(message: => String)(implicit mc: MarkerContext): Unit = super.info(prefixLog(message))
     override def warn(message: => String)(implicit mc: MarkerContext): Unit = super.warn(prefixLog(message))
     override def error(message: => String)(implicit mc: MarkerContext): Unit = super.error(prefixLog(message))
+
+    override def debug(message: => String, e: => Throwable)(implicit mc: MarkerContext): Unit = super.debug(prefixLog(message), e)
+    override def info(message: => String, e: => Throwable)(implicit mc: MarkerContext): Unit = super.info(prefixLog(message), e)
+    override def warn(message: => String, e: => Throwable)(implicit mc: MarkerContext): Unit = super.warn(prefixLog(message), e)
+    override def error(message: => String, e: => Throwable)(implicit mc: MarkerContext): Unit = super.error(prefixLog(message), e)
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -74,15 +74,8 @@ play.i18n.langs=["en"]
 
 # Router
 # ~~~~~
-# Define the Router object to use for this application.
-# This router will be looked up first when the application is starting up,
-# so make sure this is the entry point.
-# Furthermore, it's assumed your route file is named properly.
-# So for an application router like `my.application.Router`,
-# you may need to define a router file `conf/my.application.routes`.
-# Default to Routes in the root package (and conf/routes)
-# !!!WARNING!!! DO NOT CHANGE THIS ROUTER
-application.router=prod.Routes
+play.http.router=prod.Routes
+
 use-https-fire-subs=false
 akka.quartz {
   threadPool {

--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -51,13 +51,13 @@
 
     <logger name="uk.gov" level="OFF"/>
 
-    <logger name="application" level="ERROR"/>
+    <logger name="application" level="DEBUG"/>
 
     <logger name="connector" level="ERROR">
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <root level="ERROR">
+    <root level="WARN">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -4,19 +4,19 @@
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/incorporation-information.log</file>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>[%highlight(%.-4level)] rid=[%X{X-Request-ID}] user=[%X{Authorization}] %message %replace(exception=[%xException]){'^exception=\[\]$',''} %date{ISO8601} %n</pattern>
         </encoder>
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>[%highlight(%.-4level)] rid=[%X{X-Request-ID}] user=[%X{Authorization}] %message %replace(exception=[%xException]){'^exception=\[\]$',''} %date{ISO8601} %n</pattern>
         </encoder>
     </appender>
 
     <appender name="STDOUT_IGNORE_NETTY" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[not-available] user=[not-available] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>[%highlight(%.-4level)] rid=[%X{X-Request-ID}] user=[%X{Authorization}] %message %replace(exception=[%xException]){'^exception=\[\]$',''} %date{ISO8601} %n</pattern>
         </encoder>
     </appender>
 
@@ -63,7 +63,7 @@
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <root level="DEBUG">
+    <root level="WARN">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/it/jobs/ProactiveMonitoringISpec.scala
+++ b/it/jobs/ProactiveMonitoringISpec.scala
@@ -75,8 +75,8 @@ class ProactiveMonitoringISpec extends IntegrationSpecBase with FakeAppConfig
       stubFetchTransactionalAPI(502)
       stubFetchCompanyProfilePublicAPI(502)
 
-      withCaptureOfLoggingFrom(Logger("application.IncorporationAPIConnectorImpl")) { incorpApiConnectorLogs =>
-        withCaptureOfLoggingFrom(Logger("application.PublicCohoApiConnectorImpl")) { publicCohoApiConnectorLogs =>
+      withCaptureOfLoggingFrom(Logger("application.connectors.IncorporationAPIConnectorImpl")) { incorpApiConnectorLogs =>
+        withCaptureOfLoggingFrom(Logger("application.connectors.PublicCohoApiConnectorImpl")) { publicCohoApiConnectorLogs =>
           val (txApiResponse, publicApiResponse) = await(service.pollAPIs)
           txApiResponse mustBe "polling transactional API - failed"
           publicApiResponse mustBe "polling public API - failed"

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -9,7 +9,7 @@
  <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
   <parameters>
    <parameter name="header"><![CDATA[/*
-* Copyright 2021 HM Revenue & Customs
+* Copyright 2022 HM Revenue & Customs
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/test/config/AppStartupJobsSpec.scala
+++ b/test/config/AppStartupJobsSpec.scala
@@ -91,11 +91,11 @@ class AppStartupJobsSpec extends SCRSSpec with LogCapturing with Eventually with
       when(mockSubsRepo.getSubscriptionsByRegime(eqTo("ct"), eqTo(20))).thenReturn(Future.successful(subscriptions))
 
       val expectedLogOfSubscriptions = {
-        List("[StartUpJobs] Logging existing subscriptions for ct regime, found 5 subscriptions") ++
-          List.fill(5)("[StartUpJobs] [Subscription] [ct] Transaction ID: transId, Subscriber: testSubscriber")
+        List("[StartUpJobs][logRemainingSubscriptionIdentifiers] Logging existing subscriptions for ct regime, found 5 subscriptions") ++
+          List.fill(5)("[StartUpJobs][logRemainingSubscriptionIdentifiers][ct] Transaction ID: transId, Subscriber: testSubscriber")
       }
 
-      withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
+      withCaptureOfLoggingFrom(Logger("application.config.StartUpJobs")) { logEvents =>
 
         val t0 = System.currentTimeMillis()
 
@@ -128,11 +128,11 @@ class AppStartupJobsSpec extends SCRSSpec with LogCapturing with Eventually with
         when(mockSubsRepo.getSubscriptionsByRegime(eqTo("ct"), eqTo(20))).thenReturn(Future.successful(subscriptions))
 
         val expectedLogOfSubscriptions = {
-          List("[StartUpJobs] Logging existing subscriptions for ct regime, found 5 subscriptions") ++
-            List.fill(5)("[StartUpJobs] [Subscription] [ct] Transaction ID: transId, Subscriber: testSubscriber")
+          List("[StartUpJobs][logRemainingSubscriptionIdentifiers] Logging existing subscriptions for ct regime, found 5 subscriptions") ++
+            List.fill(5)("[StartUpJobs][logRemainingSubscriptionIdentifiers][ct] Transaction ID: transId, Subscriber: testSubscriber")
         }
 
-        withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
+        withCaptureOfLoggingFrom(Logger("application.config.StartUpJobs")) { logEvents =>
           appStartupJobs(Configuration())
           eventually {
             logEvents.map(_.getMessage).count(r => expectedLogOfSubscriptions.contains(r)) mustBe 6
@@ -150,12 +150,12 @@ class AppStartupJobsSpec extends SCRSSpec with LogCapturing with Eventually with
 
         when(mockSubsRepo.getSubscriptionsByRegime(any(), any())) thenReturn Future.successful(Seq())
 
-        withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
+        withCaptureOfLoggingFrom(Logger("application.config.StartUpJobs")) { logEvents =>
           appStartupJobs(Configuration())
           eventually {
 
             val expectedLogs = List(
-              "[StartUpJobs] Logging existing subscriptions for ct regime, found 0 subscriptions"
+              "[StartUpJobs][logRemainingSubscriptionIdentifiers] Logging existing subscriptions for ct regime, found 0 subscriptions"
             )
             logEvents.map(_.getMessage).count(r => expectedLogs.contains(r)) mustBe 1
           }
@@ -196,12 +196,12 @@ class AppStartupJobsSpec extends SCRSSpec with LogCapturing with Eventually with
           .thenReturn(Future.successful(None))
 
         val expectedLogs = List(
-          "[StartUpJobs] [HeldDocs] For txId: trans-1 - subscriptions: List(Subscription(trans-1,testRegime,testSubscriber,testCallbackUrl)) - " +
+          "[StartUpJobs][logIncorpInfo][HeldDocs] For txId: trans-1 - subscriptions: List(Subscription(trans-1,testRegime,testSubscriber,testCallbackUrl)) - " +
             "incorp update: incorp status: accepted - incorp date: Some(2010-06-30T01:20:00.0) - crn: Some(crn-1) - timepoint: 12345 - queue: In queue",
-          "[StartUpJobs] [HeldDocs] For txId: trans-2 - subscriptions: No subs - incorp update: No incorp update - queue: No queued incorp update"
+          "[StartUpJobs][logIncorpInfo][HeldDocs] For txId: trans-2 - subscriptions: No subs - incorp update: No incorp update - queue: No queued incorp update"
         )
 
-        withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
+        withCaptureOfLoggingFrom(Logger("application.config.StartUpJobs")) { logEvents =>
 
           appStartupJobs(Configuration.from(Map("transactionIdList" -> "dHJhbnMtMSx0cmFucy0y")))
           eventually {
@@ -216,7 +216,7 @@ class AppStartupJobsSpec extends SCRSSpec with LogCapturing with Eventually with
         when(mockQueueMongo.repo).thenReturn(mockQueueRepo)
         when(mockIIService.updateSpecificIncorpUpdateByTP(any(), any())(any(), any())).thenReturn(Future.successful(Seq()))
         when(mockSubsRepo.getSubscriptionsByRegime(any(), any())).thenReturn(Future.successful(Seq()))
-        withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
+        withCaptureOfLoggingFrom(Logger("application.config.StartUpJobs")) { logEvents =>
           appStartupJobs(Configuration())
           eventually {
             logEvents.map(_.getMessage).filter(_.contains("[HeldDocs]")) mustBe empty
@@ -254,13 +254,13 @@ class AppStartupJobsSpec extends SCRSSpec with LogCapturing with Eventually with
           .thenReturn(Future.successful(true))
 
 
-        withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
+        withCaptureOfLoggingFrom(Logger("application.config.StartUpJobs")) { logEvents =>
           appStartupJobs(Configuration.from(Map("brokenTxIds" -> encodedTransIds)))
 
           eventually {
             val expectedLogs = List(
-              "[StartUpJobs] [Start Up] Removed broken submission with txId: trans-1 - delete sub: AcknowledgedDeleteResult{deletedCount=1} queue result: true",
-              "[StartUpJobs] [Start Up] Removed broken submission with txId: trans-2 - delete sub: AcknowledgedDeleteResult{deletedCount=1} queue result: true"
+              "[StartUpJobs][removeBrokenSubmissions] Removed broken submission with txId: trans-1 - delete sub: AcknowledgedDeleteResult{deletedCount=1} queue result: true",
+              "[StartUpJobs][removeBrokenSubmissions] Removed broken submission with txId: trans-2 - delete sub: AcknowledgedDeleteResult{deletedCount=1} queue result: true"
             )
             logEvents.map(_.getMessage).count(expectedLogs.contains(_)) mustBe 2
           }
@@ -274,12 +274,12 @@ class AppStartupJobsSpec extends SCRSSpec with LogCapturing with Eventually with
 
         when(mockSubsRepo.getSubscriptionsByRegime(any(), any())) thenReturn Future.successful(Seq())
 
-        withCaptureOfLoggingFrom(Logger("application.StartUpJobs")) { logEvents =>
+        withCaptureOfLoggingFrom(Logger("application.config.StartUpJobs")) { logEvents =>
           appStartupJobs(Configuration.from(Map()))
 
           eventually {
             val expectedLogs = List(
-              "[StartUpJobs] [Start Up] No broken submissions in config"
+              "[StartUpJobs][removeBrokenSubmissions] No broken submissions in config"
             )
             logEvents.map(_.getMessage).count(expectedLogs.contains(_)) mustBe 1
           }

--- a/test/connectors/PublicCohoApiConnectorSpec.scala
+++ b/test/connectors/PublicCohoApiConnectorSpec.scala
@@ -140,7 +140,7 @@ class PublicCohoApiConnectorSpec extends SCRSSpec with LogCapturing with Eventua
 
       withCaptureOfLoggingFrom(Connector.logger) { logEvents =>
         await(Connector.getCompanyProfile(testCrn, isScrs = false)) mustBe None
-        logEvents.map(_.getMessage) mustBe List("[Connector] Could not find company data for CRN - 1234567890")
+        logEvents.map(_.getMessage) mustBe List("[Connector][getCompanyProfile] Could not find company data for CRN - 1234567890")
         logEvents.size mustBe 1
       }
     }

--- a/test/models/ShareholdersSpec.scala
+++ b/test/models/ShareholdersSpec.scala
@@ -42,10 +42,9 @@ class ShareholdersSpec extends SCRSSpec with LogCapturing{
         """.stripMargin)
     withCaptureOfLoggingFrom(Shareholders.logger) { logEvents =>
       json.as[Option[JsArray]](Shareholders.reads).isDefined mustBe false
-      val message = "[ShareholdersReads] 'shareholders' is not an array"
       val log =  logEvents.map(l => (l.getLevel, l.getMessage)).head
       log._1.toString mustBe "ERROR"
-      log._2 mustBe s"[Shareholders] ${message}"
+      log._2 mustBe s"[Shareholders][ShareholdersReads] 'shareholders' is not an array"
     }
   }
   "return Some if key exists and is jsArray" in {

--- a/test/repositories/IncorpUpdateRepositorySpec.scala
+++ b/test/repositories/IncorpUpdateRepositorySpec.scala
@@ -57,7 +57,7 @@ class IncorpUpdateRepositorySpec extends SCRSSpec with MongoSupport with LogCapt
 
         logEvents.size mustBe 1
         logEvents.head.getLevel mustBe Level.INFO
-        logEvents.head.getMessage mustBe "[Repository] [UniqueIncorp] transactionId : trans2"
+        logEvents.head.getMessage mustBe "[Repository][UniqueIncorp] transactionId : trans2"
       }
     }
 
@@ -79,7 +79,7 @@ class IncorpUpdateRepositorySpec extends SCRSSpec with MongoSupport with LogCapt
 
         logEvents.size mustBe 1
         logEvents.head.getLevel mustBe Level.INFO
-        logEvents.head.getMessage mustBe "[Repository] [UniqueIncorp] transactionId : trans2"
+        logEvents.head.getMessage mustBe "[Repository][UniqueIncorp] transactionId : trans2"
       }
     }
 
@@ -110,11 +110,11 @@ class IncorpUpdateRepositorySpec extends SCRSSpec with MongoSupport with LogCapt
 
         logEvents.size mustBe 3
         logEvents.head.getLevel mustBe Level.INFO
-        logEvents.head.getMessage mustBe "[Repository] [UniqueIncorp] transactionId : trans1"
+        logEvents.head.getMessage mustBe "[Repository][UniqueIncorp] transactionId : trans1"
         logEvents.apply(1).getLevel mustBe Level.INFO
-        logEvents.apply(1).getMessage mustBe "[Repository] [UniqueIncorp] transactionId : trans2"
+        logEvents.apply(1).getMessage mustBe "[Repository][UniqueIncorp] transactionId : trans2"
         logEvents.apply(2).getLevel mustBe Level.INFO
-        logEvents.apply(2).getMessage mustBe "[Repository] [UniqueIncorp] transactionId : trans3"
+        logEvents.apply(2).getMessage mustBe "[Repository][UniqueIncorp] transactionId : trans3"
       }
     }
   }

--- a/test/services/IncorpUpdateServiceSpec.scala
+++ b/test/services/IncorpUpdateServiceSpec.scala
@@ -256,7 +256,7 @@ class IncorpUpdateServiceSpec extends SCRSSpec with JSONhelpers with LogCapturin
     "throw a PAGER DUTY log message at level ERROR if working day true and timepoint cannot be parsed" in new Setup(nDCalc(mondayWorking)) {
       withCaptureOfLoggingFrom(Service.logger) { loggingEvents =>
         Service.latestTimepoint(incorpUpdatesNonParsable) mustBe badNonParsableTimePoint.toString
-        loggingEvents.head.getMessage mustBe "[Service] couldn't parse Foobar"
+        loggingEvents.head.getMessage mustBe "[Service][timepointValidator] couldn't parse Foobar"
         loggingEvents.tail.head.getMessage mustBe s"[Service] ${PagerDutyKeys.TIMEPOINT_INVALID} - last timepoint received from coho invalid: ${inu4BADNonParsable.timepoint}"
       }
     }

--- a/test/services/TransactionalServiceSpec.scala
+++ b/test/services/TransactionalServiceSpec.scala
@@ -1312,10 +1312,9 @@ class TransactionalServiceSpec extends SCRSSpec with LogCapturing {
         .thenReturn(Future.successful(SuccessfulTransactionalAPIResponse(txJsonContainingShareholders)))
       withCaptureOfLoggingFrom(Service.logger) { logEvents =>
         await(Service.fetchShareholders(transactionId)) mustBe Some(extractedJson)
-        val message = "[fetchShareholders] returned an array with the size - 1"
         val log =  logEvents.map(l => (l.getLevel, l.getMessage)).head
         log._1.toString mustBe "INFO"
-        log._2 mustBe s"[Service] ${message}"
+        log._2 mustBe s"[Service][fetchShareholders] returned an array with the size - 1"
       }
     }
     "return JsArray containing empty list of shareholders, but key exists logging size at level WARN" in new Setup {
@@ -1337,10 +1336,9 @@ class TransactionalServiceSpec extends SCRSSpec with LogCapturing {
         .thenReturn(Future.successful(SuccessfulTransactionalAPIResponse(txJsonContainingEmptyListOfShareholders)))
       withCaptureOfLoggingFrom(Service.logger) { logEvents =>
         await(Service.fetchShareholders(transactionId)) mustBe Some(extractedJson)
-        val message = "[fetchShareholders] returned an array with the size - 0"
         val log = logEvents.map(l => (l.getLevel, l.getMessage)).head
         log._1.toString mustBe "WARN"
-        log._2 mustBe s"[Service] ${message}"
+        log._2 mustBe s"[Service][fetchShareholders] returned an array with the size - 0"
       }
     }
     "return None when key does not exist" in new Setup {
@@ -1357,10 +1355,9 @@ class TransactionalServiceSpec extends SCRSSpec with LogCapturing {
         .thenReturn(Future.successful(SuccessfulTransactionalAPIResponse(txJsonContainingNOShareholdersKey)))
       withCaptureOfLoggingFrom(Service.logger) { logEvents =>
         await(Service.fetchShareholders(transactionId)) mustBe None
-        val message = "[fetchShareholders] returned nothing as key 'shareholders' was not found"
         val log = logEvents.map(l => (l.getLevel, l.getMessage)).head
         log._1.toString mustBe "INFO"
-        log._2 mustBe s"[Service] ${message}"
+        log._2 mustBe s"[Service][fetchShareholders] returned nothing as key 'shareholders' was not found"
       }
     }
   }

--- a/test/utils/LoggingSpec.scala
+++ b/test/utils/LoggingSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import Helpers.LogCapturing
+import ch.qos.logback.classic.Level
+import org.scalatestplus.play.PlaySpec
+
+class LoggingSpec extends PlaySpec with LogCapturing {
+
+  val ex = new Exception("foobar")
+
+  object TestLogging extends Logging
+
+  "have the logger configured correctly" in {
+    TestLogging.logger.logger.getName mustBe "application.utils.TestLogging"
+  }
+
+  "when logging" must {
+
+    withCaptureOfLoggingFrom(TestLogging.logger) { logs =>
+      Seq(
+        Level.DEBUG -> TestLogging.logger.debug(s"${Level.DEBUG} Message"),
+        Level.INFO -> TestLogging.logger.info(s"${Level.INFO} Message"),
+        Level.WARN -> TestLogging.logger.warn(s"${Level.WARN} Message"),
+        Level.ERROR -> TestLogging.logger.error(s"${Level.ERROR} Message")
+      ) foreach {
+
+        case (level, _) =>
+
+          s"at level $level" must {
+
+            s"output the correct message and level (prefixing with the class/object name)" in {
+              logs.exists(log => log.getMessage == s"[TestLogging] $level Message" && log.getLevel == level) mustBe true
+            }
+          }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hopefully this can be rolled out across the other services. The highlights are:
- Logger created per class by mixed in `Logging` trait
- The logger created has the name `application.{package}.{className}`
    - this allows a global application logging level to be set
    - but also will allow for different levels by package in future if needed _(extra entries would be needed in application-json-logger.xml)_. E.g.:
    ```
         <logger name="application" level="${logger.application:-WARN}"/>
         <logger name="application.connectors" level="${logger.application.connectors:-INFO}"/>
    ```
- Prefix all logs with the `[className]`
- Also prefix the log message with `[MethodName]` where appropriate