### PR TITLE
[DL-18873] Temp Fix: Change incorporation-information to process CoHo documents in descending timestamp order rather than ascending

### DIFF
--- a/app/repositories/QueueRepository.scala
+++ b/app/repositories/QueueRepository.scala
@@ -111,7 +111,7 @@ class QueueMongoRepository(mongo: MongoComponent, format: Format[QueuedIncorpUpd
   override def getIncorpUpdates(fetchSize: Int): Future[Seq[QueuedIncorpUpdate]] =
     collection
       .find(lte("timestamp", Instant.now().toEpochMilli))
-      .sort(Sorts.ascending("timestamp"))
+      .sort(Sorts.descending("timestamp")) // 31/03/2026 - DL-18873: Temp reversal from ASC to DESC
       .limit(fetchSize)
       .toFuture()
 

--- a/it/test/repositories/QueueRepositoryISpec.scala
+++ b/it/test/repositories/QueueRepositoryISpec.scala
@@ -98,7 +98,8 @@ class QueueRepositoryISpec extends SCRSMongoSpec with DateCalculators {
 
       val result = await(repo.getIncorpUpdates(10))
 
-      result mustBe Seq(q1, q2)
+//      result mustBe Seq(q1, q2) // DL-18873: Temp reversal from ASC to DESC
+      result mustBe Seq(q2, q1)
     }
 
     "return the updates in the correct order #2" in new Setup {
@@ -112,7 +113,8 @@ class QueueRepositoryISpec extends SCRSMongoSpec with DateCalculators {
 
       val result = await(repo.getIncorpUpdates(10))
 
-      result mustBe Seq(q2, q1)
+//      result mustBe Seq(q2, q1) // DL-18873: Temp reversal from ASC to DESC
+      result mustBe Seq(q1, q2)
     }
 
     "return the updates in the correct order, eliding the ones in the future" in new Setup {
@@ -129,7 +131,8 @@ class QueueRepositoryISpec extends SCRSMongoSpec with DateCalculators {
 
       val result = await(repo.getIncorpUpdates(10))
 
-      result mustBe Seq(q3, q1, q6, q5)
+//      result mustBe Seq(q3, q1, q6, q5) // DL-18873: Temp reversal from ASC to DESC
+      result mustBe Seq(q5, q6, q1, q3)
     }
   }
 
@@ -146,8 +149,9 @@ class QueueRepositoryISpec extends SCRSMongoSpec with DateCalculators {
     await(Future.sequence(Seq(q1, q2, q3, q4, q5, q6) map (fInsert(_))))
 
     val result = await(repo.getIncorpUpdates(2))
-
-    result mustBe Seq(q3, q1)
+    
+//    result mustBe Seq(q3, q1) // DL-18873: Temp reversal from ASC to DESC
+    result mustBe Seq(q5, q6)
   }
 
   "getIncorpUpdate" must {


### PR DESCRIPTION
SCRS outage has reset the timestamp for clearing documents. 
To unblock the submissions while a complete fix is found, we are reversing the clearing from ascending date to descending date order.